### PR TITLE
formatted episode duration to properly display leading seconds

### DIFF
--- a/lib/elixir_newbie_web/live/blog_list.ex
+++ b/lib/elixir_newbie_web/live/blog_list.ex
@@ -19,7 +19,6 @@ defmodule ElixirNewbieWeb.BlogList do
 
   def mount(_params, _session, socket) do
     blogs = Blog.all_posts()
-    IO.inspect(blogs)
     tags = Blog.all_tags()
 
     {:ok,

--- a/lib/elixir_newbie_web/live/blog_list.ex
+++ b/lib/elixir_newbie_web/live/blog_list.ex
@@ -19,6 +19,7 @@ defmodule ElixirNewbieWeb.BlogList do
 
   def mount(_params, _session, socket) do
     blogs = Blog.all_posts()
+    IO.inspect(blogs)
     tags = Blog.all_tags()
 
     {:ok,
@@ -82,8 +83,8 @@ defmodule ElixirNewbieWeb.BlogList do
           </figure>
         </article>
         <figure>
-          <img class={"animate-fade-in m-auto w-3/4 my-12"} src={Routes.static_path(ElixirNewbieWeb.Endpoint, "/images/magic_books.png")}/>
-        </figure>
+        <img class={"animate-fade-in m-auto w-3/4 my-12"} src={Routes.static_path(ElixirNewbieWeb.Endpoint, "/images/magic_books.png")}/>
+      </figure>
       </ResponsiveLayout>
       <ResponsiveLayout class="mt-12" scroll_id={"all_blogs"} cols={3} spacing="full">
         {#for blog <- @blogs}

--- a/lib/elixir_newbie_web/live/podcast_list.ex
+++ b/lib/elixir_newbie_web/live/podcast_list.ex
@@ -99,7 +99,7 @@ defmodule ElixirNewbieWeb.PodcastList do
         <article class="flex items-center">
           <img class="w-16 mr-8 rounded-lg" src={episode.artwork_url}/>
           <p class="text-2xl text-white">{episode.title}</p>
-          <p class="ml-auto text-white">{div episode.duration, 60}:{rem episode.duration, 60}</p>
+          <p class="ml-auto text-white">{format_episode_duration(episode.duration)}</p>
         </article>
       </LiveRedirect>
       <hr/>
@@ -148,4 +148,13 @@ defmodule ElixirNewbieWeb.PodcastList do
       Podcast.query_episodes(PodcastCache, season_number: season_number, order: order)
     )
   end
+
+  #{div(episode.duration, 60)} {String.pad_leading("#{rem(episode.duration, 60)}", 2, "0")}
+
+  defp format_episode_duration(episode_duration) do
+    minutes = div(episode_duration, 60)
+    seconds = String.pad_leading("#{rem(episode_duration, 60)}", 2, "0")
+    "#{minutes}:#{seconds}"
+  end
+
 end

--- a/lib/elixir_newbie_web/live/podcast_list.ex
+++ b/lib/elixir_newbie_web/live/podcast_list.ex
@@ -149,8 +149,6 @@ defmodule ElixirNewbieWeb.PodcastList do
     )
   end
 
-  #{div(episode.duration, 60)} {String.pad_leading("#{rem(episode.duration, 60)}", 2, "0")}
-
   defp format_episode_duration(episode_duration) do
     minutes = div(episode_duration, 60)
     seconds = String.pad_leading("#{rem(episode_duration, 60)}", 2, "0")


### PR DESCRIPTION
Podcast episodes with time length that have remainder of seconds (that have a leading zero) are now displayed properly. 