### PR TITLE
Add author attribution to blog posts

### DIFF
--- a/lib/elixir_newbie/blog/post.ex
+++ b/lib/elixir_newbie/blog/post.ex
@@ -1,6 +1,11 @@
 defmodule ElixirNewbie.Blog.Post do
   @enforce_keys [:id, :title, :cover_image, :body, :description, :tags, :date]
-  defstruct @enforce_keys ++ [:livebook_url, author_name: "Brooklin Myers"]
+  defstruct @enforce_keys ++
+              [
+                :livebook_url,
+                author_name: "Brooklin Myers",
+                author_picture: "/images/authors/brooklin_myers_profile_pic.png"
+              ]
 
   def build(filename, attrs, body) do
     [year, month_day_id] = filename |> Path.rootname() |> Path.split() |> Enum.take(-2)

--- a/lib/elixir_newbie_web/components/author.ex
+++ b/lib/elixir_newbie_web/components/author.ex
@@ -1,0 +1,24 @@
+defmodule ElixirNewbieWeb.Components.Author do
+  use Surface.Component
+  prop author_name, :string, required: true
+  prop blog_date, :string, required: true
+  prop author_picture, :string, required: false
+
+  def render(assigns) do
+    ~F"""
+      <div class="flex flex-row mb-8">
+      {#unless is_nil(@author_picture)}
+        <div class="basis-1/4 mr-3">
+          <img src={@author_picture} class="rounded-full border-solid border-2 h-[48px] w-[48px]">
+        </div>
+      {/unless}
+        <div class="basis-3/4 flex flex-col justify-between text-sm">
+          <div>{@author_name}</div>
+          <div class="text-gray-300">
+            {Calendar.strftime(NaiveDateTime.new!(@blog_date, Time.utc_now()), "%B %d %Y")}
+          </div>
+        </div>
+      </div>
+    """
+  end
+end

--- a/lib/elixir_newbie_web/live/blog_show.ex
+++ b/lib/elixir_newbie_web/live/blog_show.ex
@@ -13,6 +13,7 @@ defmodule ElixirNewbieWeb.BlogShow do
   alias ElixirNewbieWeb.Components.BlogCard
   alias ElixirNewbieWeb.Components.CardContainer
   alias ElixirNewbieWeb.Components.IconButton
+  alias ElixirNewbieWeb.Components.Author
   alias ElixirNewbieWeb.Live.Home.Footer
   alias ElixirNewbieWeb.Components.SubTitle
   alias ElixirNewbieWeb.Router.Helpers, as: Routes
@@ -39,6 +40,7 @@ defmodule ElixirNewbieWeb.BlogShow do
     ~F"""
     <Page loading={@loading}>
       <section class={"mx-6 my-6 leading-loose text-white max-w-full lg:mx-60 md:mx-24"}>
+        <Author author_name={@blog.author_name} author_picture={@blog.author_picture} blog_date={@blog.date}></Author>
         <Title class="mb-4">{@blog.title}</Title>
         <SubTitle class="mb-4 italic">{@blog.description}</SubTitle>
         <img class="mb-4 rounded-2xl" src={Routes.static_path(ElixirNewbieWeb.Endpoint, "/images/posts/#{@blog.cover_image}")}/>

--- a/lib/elixir_newbie_web/live/podcast_list.ex
+++ b/lib/elixir_newbie_web/live/podcast_list.ex
@@ -154,5 +154,4 @@ defmodule ElixirNewbieWeb.PodcastList do
     seconds = String.pad_leading("#{rem(episode_duration, 60)}", 2, "0")
     "#{minutes}:#{seconds}"
   end
-
 end


### PR DESCRIPTION
Resolve #12 

Add author_picture into Post.
Create Author component to show author information.
Add author component into blog_show.ex.

The final result:

![image](https://user-images.githubusercontent.com/3181570/190191635-2e981dd6-b768-426d-87e3-a05e593218c1.png)
